### PR TITLE
Execute configure request in fetchFirst if passed

### DIFF
--- a/Sources/CoreDataKit/ManagedObject.swift
+++ b/Sources/CoreDataKit/ManagedObject.swift
@@ -67,6 +67,7 @@ extension ManagedObject where Self: NSManagedObject {
     
     public static func fetchFirst(_ context: NSManagedObjectContext, configure: configureRequest? = nil) -> Self? {
         let result = Self.fetch(context) { request in
+            if let configure = configure { configure(request) }
             request.returnsObjectsAsFaults = false
             request.fetchLimit = 1
         }


### PR DESCRIPTION
@kharrison Thanks for the wonderful library. 

Configure request closure is unused in case of `fetchFirst` function, adding it such that closure is executed if set.